### PR TITLE
Updated VGR ICC CheckStyle config

### DIFF
--- a/dev-environment/checkstyle/vgr_icc_checkstyle_config.xml
+++ b/dev-environment/checkstyle/vgr_icc_checkstyle_config.xml
@@ -87,7 +87,6 @@
     <module name="SimplifyBooleanExpression"/>
     <module name="SimplifyBooleanReturn"/>
     <module name="FinalClass"/>
-    <module name="HideUtilityClassConstructor"/>
     <module name="InterfaceIsType"/>
     <module name="VisibilityModifier">
       <property name="packageAllowed" value="true"/>


### PR DESCRIPTION
Removed HideUtilityClassConstructor since it will complain about Spring configuration classes having a public constructor.