### PR TITLE
Uppdaterat checkstyle för att stöda @SuppressWarnings annotationer

### DIFF
--- a/dev-environment/checkstyle/vgr_icc_checkstyle_config.xml
+++ b/dev-environment/checkstyle/vgr_icc_checkstyle_config.xml
@@ -10,6 +10,7 @@
 -->
 <module name="Checker">
   <property name="severity" value="warning"/>
+  <module name="SuppressWarningsFilter"/>
   <module name="TreeWalker">
     <property name="tabWidth" value="4"/>
     <module name="JavadocMethod">
@@ -94,6 +95,7 @@
       <property name="severity" value="ignore"/>
       <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
     </module>
+    <module name="SuppressWarningsHolder" />
   </module>
   <module name="Translation"/>
   <module name="FileLength"/>


### PR DESCRIPTION
Stöd att tysta checkstyle med mer fingranulära annotationer, såsom @SuppressWarnings({"checkstyle:modifierorder"}) än tidigare något yxiga //CHECKSTYLE:OFF