### PR TITLE
Added ignoreAnnotationCanonicalNames to ModifierVisibilityCheck. Allo…

### DIFF
--- a/dev-environment/checkstyle/vgr_icc_checkstyle_config.xml
+++ b/dev-environment/checkstyle/vgr_icc_checkstyle_config.xml
@@ -87,6 +87,7 @@
     <module name="VisibilityModifier">
       <property name="packageAllowed" value="true"/>
       <property name="protectedAllowed" value="true"/>
+      <property name="ignoreAnnotationCanonicalNames"/>
     </module>
     <module name="ArrayTypeStyle"/>
     <module name="TodoComment"/>


### PR DESCRIPTION
…ws public for @org.junit.Rule annotations (and com.google.annotations.VisibleForTesting)

I.e. allows:

@Rule public TemporaryFolder tempFolder = new TemporaryFolder();  (from Junit).